### PR TITLE
Fix issue where systemd user service terminates unexpectedly

### DIFF
--- a/.claude/skills/deploy-to-linux/SKILL.md
+++ b/.claude/skills/deploy-to-linux/SKILL.md
@@ -162,6 +162,19 @@ Copy SSH authorized keys so the user can SSH directly:
 ssh root@IP_ADDRESS 'mkdir -p /home/nanoclaw/.ssh && cp /root/.ssh/authorized_keys /home/nanoclaw/.ssh/authorized_keys && chown -R nanoclaw:nanoclaw /home/nanoclaw/.ssh && chmod 700 /home/nanoclaw/.ssh && chmod 600 /home/nanoclaw/.ssh/authorized_keys'
 ```
 
+Enable **lingering** so the user's systemd instance (and nanoclaw service) survives SSH disconnects and starts automatically at boot:
+
+```bash
+ssh root@IP_ADDRESS 'loginctl enable-linger nanoclaw'
+```
+
+Verify:
+
+```bash
+ssh root@IP_ADDRESS 'loginctl show-user nanoclaw | grep Linger'
+# Expected: Linger=yes
+```
+
 Verify direct SSH works:
 
 ```bash

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -11,6 +11,19 @@ Run setup scripts automatically. Only pause when user action is required (WhatsA
 
 **UX Note:** Use `AskUserQuestion` for all user-facing questions.
 
+## 0. Deployment Context
+
+Before doing anything else, ask:
+
+AskUserQuestion: Are you setting this up on a remote or cloud Linux server (e.g. a VPS, Hetzner, DigitalOcean, etc.)?
+
+**If yes:** Recommend `/deploy-to-linux` instead — it handles server provisioning, user account setup, lingering (so the service survives reboots), and runs `/setup` for you as part of the process. Ask if they'd like to switch to that skill.
+
+- If they want to switch → stop here and invoke the `/deploy-to-linux` skill.
+- If they want to continue with `/setup` directly → proceed to step 1.
+
+**If no (local machine):** Proceed directly to step 1.
+
 ## 1. Check Environment
 
 Run `./.claude/skills/setup/scripts/01-check-environment.sh` and parse the status block.
@@ -158,6 +171,8 @@ Tell user how to grant a group access: add `containerConfig.additionalMounts` to
 If the service is already running (check `launchctl list | grep nanoclaw` on macOS), unload it first: `launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist` — then proceed with a clean install.
 
 Run `./.claude/skills/setup/scripts/08-setup-service.sh` and parse the status block.
+
+**If LINGER_ENABLED=false (Linux only):** Warn the user: lingering is not enabled, so the service will not start automatically at boot or survive SSH disconnects. The fix requires root: `sudo loginctl enable-linger $USER` (or `loginctl enable-linger USERNAME` as root). Note that the `/deploy-to-linux` skill handles this automatically as part of server provisioning.
 
 **If SERVICE_LOADED=false:**
 - Read `logs/setup.log` for the error.

--- a/.claude/skills/setup/scripts/08-setup-service.sh
+++ b/.claude/skills/setup/scripts/08-setup-service.sh
@@ -167,6 +167,13 @@ UNITEOF
       log "Service not active"
     fi
 
+    # Check lingering — required for the service to survive reboots and SSH disconnects
+    LINGER_ENABLED="true"
+    if ! loginctl show-user "$USER" 2>/dev/null | grep -q "Linger=yes"; then
+      LINGER_ENABLED="false"
+      log "WARNING: Lingering not enabled for $USER"
+    fi
+
     cat <<EOF
 === NANOCLAW SETUP: SETUP_SERVICE ===
 SERVICE_TYPE: systemd
@@ -174,6 +181,7 @@ NODE_PATH: $NODE_PATH
 PROJECT_PATH: $PROJECT_PATH
 UNIT_PATH: $UNIT_PATH
 SERVICE_LOADED: $SERVICE_LOADED
+LINGER_ENABLED: $LINGER_ENABLED
 STATUS: success
 LOG: logs/setup.log
 === END ===


### PR DESCRIPTION
After using the deploy-to-linux skill to set up the remote nanoclaw server (and user), a systemd service is created and started to run this project on the server.

There was a problem where the WhatsApp connection was terminating unexpectedly. After using Claude to try and find the cause, it seems to be because the nanoclaw systemd service was being cleaned up after the nanoclaw user logged out. The service was only remaining open as long as the SSH session into the server was active.

This change updates the skills that generate that configuration to:
1. Use loginctl to allow the user's session to linger. I don't know much about this, but apparently that's a good way to make sure the service isn't cleaned up after the SSH session ends.
2. Updates the setup skill prompt the user to first use the deploy-to-linux skill FIRST if operating this service on a remote server is actually what they want to do. This is more of a quality of life improvement.

## Side note

This is my own fork, but these improvements in the form of reusable skills will never actually get used by me. The workflow is that I debug the issues, come up with fixes, try them out to verify the fix, and then at the end try to replicate never having the issue in the first place by updating the skills that could have intervened at the right time in the right way.

I recognize that this might be a waste of time (and tokens), unless I actually expect to contribute these skills back upstream (or share them in some other way with the community). Starting over with a fresh nanoclaw instance and then running these skills (in the intended ways and maybe even in some other ways) to truly test it out is a much bigger commitment, but that's what a good contribution would require.

I'm not sure what to do about this problem yet. For now, I'm kind of doing a half-good job of keeping the skills up to date so that one day I __might__ contribute them upstream. But the longer they stay in that state, the less likely they are to be useful, as upstream can drift away. And I might not even "agree with" every change upstream makes to those same skills (e.g. `/setup` starts to account for use cases I don't think are valid, or I don't think are done well).

It's also difficult to just make direct code changes for myself, without updating or sharing the skill that generated the change, because that contributes to drift from upstream. I think this is what Claude expected me to do, and even suggested deleting the skills that seemed "consumed" into the codebase after I used them (this was the case for `/convert-to-docker`). This drift makes my ability to use community or upstream skills diminish. I'd like to know what the rest of the community is doing about this - but I can't get access to the Discord, the invite link is broken, and the GitHub Issues seems a bit noisy and un-tended.

## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
