### PR TITLE
Add OpenCode as alternative container runtime

### DIFF
--- a/.claude/skills/add-model-provider/SKILL.md
+++ b/.claude/skills/add-model-provider/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: add-model-provider
+description: Add per-group model/provider configuration to NanoClaw. Routes agent requests through OpenRouter (or any OpenAI-compatible proxy) to use cheaper models like Kimi K2.5, GLM-5, DeepSeek V3.2, or Qwen 3 Coder.
+---
+
+# Add Model Provider
+
+This skill adds per-group model/provider configuration by leveraging `ANTHROPIC_BASE_URL` + `ANTHROPIC_MODEL` env vars to route Claude Agent SDK requests through OpenRouter (or any compatible proxy) to cheaper models.
+
+**UX Note:** When asking the user questions, prefer using the `AskUserQuestion` tool instead of just outputting text.
+
+## Cost Context
+
+| Model | Input/Output per 1M tokens | SWE-bench | Available On |
+|-------|---------------------------|-----------|--------------|
+| Claude Opus 4 | $15 / $75 | ~80% | Anthropic (current) |
+| Kimi K2.5 | $0.50 / $2.80 | ~77% | OpenRouter, Fireworks, Together AI |
+| GLM-5 (MIT license) | $1 / $3.20 | ~78% | OpenRouter (US/EU infra) |
+| DeepSeek V3.2 | $0.25 / $0.38 | ~68% | OpenRouter |
+| Qwen 3 Coder | Free (rate-limited) | Competitive | OpenRouter |
+
+Groups without `modelProvider` configured continue using default Anthropic — zero changes to existing behavior.
+
+---
+
+## Prerequisites
+
+**Use AskUserQuestion** to present provider choice:
+
+Question: "Which model provider would you like to use?"
+Options:
+1. **OpenRouter (Recommended)** — Access to 200+ models via single API key. Get a key at https://openrouter.ai/keys
+2. **Custom endpoint** — Any OpenAI-compatible API endpoint (e.g., self-hosted, Fireworks, Together AI)
+
+Wait for the user's choice before continuing.
+
+Then ask for:
+- API key (will be stored securely in `.env`)
+- Which model to default to (suggest Kimi K2.5 `moonshotai/kimi-k2.5` as best value)
+- Apply to all groups or specific groups?
+
+---
+
+## Implementation
+
+### Step 1: Update Types
+
+Read `src/types.ts` and add `modelProvider` to the `ContainerConfig` interface:
+
+```typescript
+export interface ContainerConfig {
+  additionalMounts?: AdditionalMount[];
+  timeout?: number; // Default: 300000 (5 minutes)
+  modelProvider?: {
+    baseUrl?: string;    // e.g. "https://openrouter.ai/api/v1"
+    apiKey?: string;     // Env var NAME to read from .env (e.g. "OPENROUTER_API_KEY")
+    model?: string;      // e.g. "moonshotai/kimi-k2.5"
+  };
+}
+```
+
+### Step 2: Update Container Runner
+
+Read `src/container-runner.ts` and make two changes:
+
+**2a.** Update `readSecrets()` to accept an optional group parameter and read the custom API key:
+
+```typescript
+function readSecrets(group?: RegisteredGroup): Record<string, string> {
+  const keys = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
+  // If group has a custom provider API key, read that too
+  const customApiKey = group?.containerConfig?.modelProvider?.apiKey;
+  if (customApiKey && !keys.includes(customApiKey)) {
+    keys.push(customApiKey);
+  }
+  return readEnvFile(keys);
+}
+```
+
+**2b.** Update the stdin writing section (~line 258) to pass `modelProvider`:
+
+Before `container.stdin.write(JSON.stringify(input))`, add:
+```typescript
+input.modelProvider = group.containerConfig?.modelProvider;
+```
+
+**2c.** Update the `ContainerInput` interface to include `modelProvider`:
+
+```typescript
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  secrets?: Record<string, string>;
+  modelProvider?: {
+    baseUrl?: string;
+    apiKey?: string;
+    model?: string;
+  };
+}
+```
+
+### Step 3: Update Agent Runner
+
+Read `container/agent-runner/src/index.ts` and make two changes:
+
+**3a.** Add `modelProvider` to the `ContainerInput` interface:
+
+```typescript
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  secrets?: Record<string, string>;
+  modelProvider?: {
+    baseUrl?: string;
+    apiKey?: string;
+    model?: string;
+  };
+}
+```
+
+**3b.** After building `sdkEnv` (after the secrets loop), inject provider overrides:
+
+```typescript
+// Inject model provider overrides (OpenRouter, custom endpoints, etc.)
+if (containerInput.modelProvider) {
+  const mp = containerInput.modelProvider;
+  if (mp.baseUrl) {
+    sdkEnv.ANTHROPIC_BASE_URL = mp.baseUrl;
+  }
+  if (mp.apiKey && containerInput.secrets?.[mp.apiKey]) {
+    sdkEnv.ANTHROPIC_API_KEY = containerInput.secrets[mp.apiKey];
+  }
+  if (mp.model) {
+    sdkEnv.ANTHROPIC_MODEL = mp.model;
+  }
+  log(`Model provider configured: base=${mp.baseUrl || 'default'} model=${mp.model || 'default'}`);
+}
+```
+
+### Step 4: Add API Key to .env
+
+Read the project `.env` file and add the user's API key. For OpenRouter:
+
+```
+OPENROUTER_API_KEY=sk-or-v1-xxxxx
+```
+
+### Step 5: Configure Group(s)
+
+Read `data/db.sqlite` group registrations using the existing SQLite database. For each group the user wants to configure, update the `containerConfig` JSON in the groups table.
+
+Example for OpenRouter + Kimi K2.5:
+```json
+{
+  "modelProvider": {
+    "baseUrl": "https://openrouter.ai/api/v1",
+    "apiKey": "OPENROUTER_API_KEY",
+    "model": "moonshotai/kimi-k2.5"
+  }
+}
+```
+
+Use the project's `src/db.ts` to understand the schema, then update via sqlite3 CLI or by reading/modifying the group config.
+
+### Step 6: Build and Verify
+
+```bash
+npm run build
+```
+
+Confirm no TypeScript errors. The container will pick up agent-runner changes on next run (source is mounted and recompiled at container startup).
+
+### Step 7: Test
+
+Tell the user:
+> Model provider configured! Send a message to the configured group to test. The agent will use [model name] via [provider].
+>
+> Groups without modelProvider configured will continue using your default Anthropic API key.
+
+---
+
+## Rollback
+
+To revert a group to default Anthropic, remove the `modelProvider` from its `containerConfig`. No code changes needed.

--- a/.claude/skills/add-opencode-runtime/SKILL.md
+++ b/.claude/skills/add-opencode-runtime/SKILL.md
@@ -1,0 +1,494 @@
+---
+name: add-opencode-runtime
+description: Add OpenCode as an alternative agent runtime alongside Claude Code. Enables per-group runtime selection with native MCP support, session persistence, and access to any model provider.
+---
+
+# Add OpenCode Runtime
+
+This skill adds OpenCode as an alternative agent runtime alongside Claude Code, giving per-group runtime selection. Uses OpenCode's `createOpencode` SDK for session persistence and SSE streaming, with native MCP support to reuse the nanoclaw MCP server.
+
+**UX Note:** When asking the user questions, prefer using the `AskUserQuestion` tool instead of just outputting text.
+
+## Overview
+
+| Concern | Resolution |
+|---------|-----------|
+| Session continuity | OpenCode server mode maintains sessions; SDK supports `session.chat()` for follow-ups |
+| CLAUDE.md support | OpenCode natively reads CLAUDE.md files (falls back from AGENTS.md) |
+| MCP servers | Native MCP support — nanoclaw MCP server configured in opencode.json |
+| Skills/instructions | OpenCode `instructions` config loads additional instruction files |
+| Streaming | SSE endpoint provides real-time events via `client.event.list()` |
+
+---
+
+## Prerequisites
+
+**Use AskUserQuestion** to ask:
+
+1. **Which model provider?**
+   - OpenRouter (Recommended) — single API key for 200+ models
+   - Anthropic — use existing Anthropic API key with OpenCode runtime
+   - Custom — any OpenAI-compatible endpoint
+
+2. **API key** — if using OpenRouter or custom (stored in `.env`)
+
+3. **Which groups to apply to?** — all groups or specific groups
+
+4. **Default runtime?** — set OpenCode as default for new groups, or per-group only
+
+---
+
+## Implementation
+
+### Step 1: Update Types
+
+Read `src/types.ts` and extend `ContainerConfig`:
+
+```typescript
+export interface ContainerConfig {
+  additionalMounts?: AdditionalMount[];
+  timeout?: number;
+  modelProvider?: ModelProvider;           // Phase 1 (may already exist)
+  runtime?: 'claude' | 'opencode';        // NEW - default: 'claude'
+  opencodeConfig?: {                       // NEW
+    provider?: string;     // e.g. 'openrouter', 'anthropic'
+    apiKey?: string;       // Env var NAME (e.g. "OPENROUTER_API_KEY")
+    model?: string;        // e.g. 'openrouter/moonshotai/kimi-k2.5'
+  };
+}
+```
+
+### Step 2: Update Dockerfile
+
+Read `container/Dockerfile` and add OpenCode installation after the claude-code line:
+
+```dockerfile
+# Install agent-browser, claude-code, and opencode globally
+RUN npm install -g agent-browser @anthropic-ai/claude-code opencode-ai
+```
+
+### Step 3: Add SDK Dependency
+
+Read `container/agent-runner/package.json` and add:
+
+```json
+"@opencode-ai/sdk": "^1.2.6"
+```
+
+Then the Dockerfile's `npm install` will pick it up on rebuild.
+
+### Step 4: Create OpenCode Runner
+
+Create `container/agent-runner/src/opencode-runner.ts` with the following implementation.
+
+This file:
+1. Starts an OpenCode server via `createOpencode` SDK
+2. Writes `opencode.json` to the workspace with provider/model/MCP/permissions config
+3. Creates a session, sends the prompt via `client.session.chat()`
+4. Streams responses via `client.event.list()` SSE
+5. Emits OUTPUT_START/END markers to stdout (same protocol as Claude runner)
+6. Handles IPC follow-up messages by sending to the same session
+7. Handles `_close` sentinel for graceful shutdown
+
+```typescript
+/**
+ * OpenCode Agent Runner
+ * Alternative runtime that uses OpenCode instead of Claude Code SDK.
+ * Same stdin/stdout protocol and IPC mechanism as the Claude runner.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createOpencode } from '@opencode-ai/sdk';
+
+// Re-use types/constants from index.ts
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  secrets?: Record<string, string>;
+  modelProvider?: { baseUrl?: string; apiKey?: string; model?: string };
+  runtime?: string;
+  opencodeConfig?: {
+    provider?: string;
+    apiKey?: string;
+    model?: string;
+  };
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+const IPC_INPUT_DIR = '/workspace/ipc/input';
+const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+const IPC_POLL_MS = 500;
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+function log(message: string): void {
+  console.error(`[opencode-runner] ${message}`);
+}
+
+function shouldClose(): boolean {
+  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    return true;
+  }
+  return false;
+}
+
+function drainIpcInput(): string[] {
+  try {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+    const files = fs.readdirSync(IPC_INPUT_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    const messages: string[] = [];
+    for (const file of files) {
+      const filePath = path.join(IPC_INPUT_DIR, file);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        fs.unlinkSync(filePath);
+        if (data.type === 'message' && data.text) {
+          messages.push(data.text);
+        }
+      } catch (err) {
+        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
+        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      }
+    }
+    return messages;
+  } catch (err) {
+    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+function waitForIpcMessage(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (shouldClose()) {
+        resolve(null);
+        return;
+      }
+      const messages = drainIpcInput();
+      if (messages.length > 0) {
+        resolve(messages.join('\n'));
+        return;
+      }
+      setTimeout(poll, IPC_POLL_MS);
+    };
+    poll();
+  });
+}
+
+/**
+ * Write opencode.json config to the workspace.
+ */
+function writeOpencodeConfig(containerInput: ContainerInput): void {
+  const oc = containerInput.opencodeConfig;
+  const provider = oc?.provider || 'anthropic';
+  const model = oc?.model || 'anthropic/claude-sonnet-4-20250514';
+
+  // Resolve API key from secrets
+  const apiKey = oc?.apiKey && containerInput.secrets?.[oc.apiKey]
+    ? containerInput.secrets[oc.apiKey]
+    : containerInput.secrets?.['ANTHROPIC_API_KEY'] || '';
+
+  // Build the MCP server path (same as Claude runner uses)
+  const mcpServerPath = '/tmp/dist/ipc-mcp-stdio.js';
+
+  const config: Record<string, unknown> = {
+    $schema: 'https://opencode.ai/config.json',
+    model,
+    permission: {
+      edit: 'allow',
+      bash: 'allow',
+      webfetch: 'allow',
+    },
+    provider: {
+      [provider]: {
+        ...(apiKey ? { apiKey } : {}),
+      },
+    },
+    mcp: {
+      nanoclaw: {
+        type: 'local',
+        command: ['node', mcpServerPath],
+        environment: {
+          NANOCLAW_CHAT_JID: containerInput.chatJid,
+          NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+          NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+        },
+      },
+    },
+    // Load CLAUDE.md and any additional instruction files
+    instructions: ['CLAUDE.md'],
+  };
+
+  const configPath = '/workspace/group/opencode.json';
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  log(`Wrote opencode.json to ${configPath}`);
+}
+
+/**
+ * Extract text from assistant message parts.
+ */
+function extractText(parts: Array<{ type: string; text?: string }>): string {
+  return parts
+    .filter(p => p.type === 'text' && p.text)
+    .map(p => p.text!)
+    .join('');
+}
+
+export async function runOpenCode(containerInput: ContainerInput): Promise<void> {
+  log('Starting OpenCode runtime...');
+
+  // Write opencode.json configuration
+  writeOpencodeConfig(containerInput);
+
+  // Start OpenCode server and get client
+  const { client, server } = await createOpencode({
+    cwd: '/workspace/group',
+    hostname: '127.0.0.1',
+    port: 4096,
+    config: {
+      model: containerInput.opencodeConfig?.model || 'anthropic/claude-sonnet-4-20250514',
+    },
+  });
+
+  log('OpenCode server started');
+
+  try {
+    // Create a session
+    const session = await client.session.create();
+    const sessionId = session.id;
+    log(`Session created: ${sessionId}`);
+
+    // Set up SSE event stream for real-time updates
+    const eventStream = await client.event.list();
+    let lastAssistantText = '';
+
+    // Process events in background
+    const eventProcessor = (async () => {
+      try {
+        for await (const event of eventStream) {
+          if (event.type === 'message.updated') {
+            // Capture assistant text as it streams in
+            const info = (event as { properties?: { info?: { parts?: Array<{ type: string; text?: string }> } } }).properties?.info;
+            if (info?.parts) {
+              lastAssistantText = extractText(info.parts);
+            }
+          }
+        }
+      } catch {
+        // Stream ended or aborted
+      }
+    })();
+
+    // Build initial prompt
+    let prompt = containerInput.prompt;
+    if (containerInput.isScheduledTask) {
+      prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
+    }
+    const pending = drainIpcInput();
+    if (pending.length > 0) {
+      prompt += '\n' + pending.join('\n');
+    }
+
+    // Query loop
+    while (true) {
+      log(`Sending prompt (${prompt.length} chars)...`);
+      lastAssistantText = '';
+
+      try {
+        const response = await client.session.chat(sessionId, {
+          parts: [{ type: 'text', text: prompt }],
+        });
+
+        // Extract result from response
+        const result = response?.parts
+          ? extractText(response.parts)
+          : lastAssistantText || null;
+
+        log(`Got response: ${result ? result.slice(0, 200) : '(empty)'}...`);
+
+        writeOutput({
+          status: 'success',
+          result,
+          newSessionId: sessionId,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log(`Query error: ${errorMessage}`);
+        writeOutput({
+          status: 'error',
+          result: null,
+          newSessionId: sessionId,
+          error: errorMessage,
+        });
+      }
+
+      // Check for close before waiting
+      if (shouldClose()) {
+        log('Close sentinel received after query, exiting');
+        break;
+      }
+
+      // Wait for next IPC message or close
+      log('Waiting for next IPC message...');
+      const nextMessage = await waitForIpcMessage();
+      if (nextMessage === null) {
+        log('Close sentinel received, exiting');
+        break;
+      }
+
+      prompt = nextMessage;
+    }
+
+    // Clean up
+    eventStream.controller.abort();
+    await eventProcessor.catch(() => {});
+  } finally {
+    server.close();
+    log('OpenCode server stopped');
+  }
+}
+```
+
+**IMPORTANT IMPLEMENTATION NOTES:**
+
+- The `createOpencode` function from `@opencode-ai/sdk` starts both the server and returns a connected client in one call.
+- The `client.session.chat()` method sends a message and waits for the complete response.
+- SSE events via `client.event.list()` provide real-time streaming updates.
+- The opencode.json file is written to `/workspace/group/` which is the cwd.
+- IPC handling (poll/drain/close) uses the exact same mechanism as the Claude runner.
+- The OUTPUT_START/END marker protocol is identical, so the host container-runner doesn't need any changes to output parsing.
+
+### Step 5: Add Runtime Dispatch
+
+Read `container/agent-runner/src/index.ts` and add runtime dispatch at the start of `main()`, right after parsing stdin and before the SDK env setup:
+
+```typescript
+// Runtime dispatch: use OpenCode if configured
+if (containerInput.runtime === 'opencode') {
+  const { runOpenCode } = await import('./opencode-runner.js');
+  await runOpenCode(containerInput);
+  return;
+}
+```
+
+Place this right after `log(\`Received input for group: ${containerInput.groupFolder}\`)` and before `// Build SDK env`.
+
+Also add `runtime` and `opencodeConfig` to the `ContainerInput` interface:
+```typescript
+interface ContainerInput {
+  // ...existing fields...
+  runtime?: 'claude' | 'opencode';
+  opencodeConfig?: {
+    provider?: string;
+    apiKey?: string;
+    model?: string;
+  };
+}
+```
+
+### Step 6: Update Container Runner (Host Side)
+
+Read `src/container-runner.ts` and update:
+
+**6a.** Add `runtime` and `opencodeConfig` to the `ContainerInput` interface:
+```typescript
+runtime?: 'claude' | 'opencode';
+opencodeConfig?: {
+  provider?: string;
+  apiKey?: string;
+  model?: string;
+};
+```
+
+**6b.** In `readSecrets()`, also read the OpenCode provider API key:
+```typescript
+const opencodeApiKey = group?.containerConfig?.opencodeConfig?.apiKey;
+if (opencodeApiKey && !keys.includes(opencodeApiKey)) {
+  keys.push(opencodeApiKey);
+}
+```
+
+**6c.** Before writing stdin, pass runtime config:
+```typescript
+input.runtime = group.containerConfig?.runtime;
+input.opencodeConfig = group.containerConfig?.opencodeConfig;
+```
+
+### Step 7: Rebuild Container
+
+```bash
+./container/build.sh
+```
+
+Verify OpenCode is installed:
+```bash
+docker run --rm --entrypoint opencode nanoclaw-agent:latest --version
+```
+
+### Step 8: Configure Group(s)
+
+Update the group's `containerConfig` in the database. Example for OpenRouter + Kimi K2.5:
+
+```json
+{
+  "runtime": "opencode",
+  "opencodeConfig": {
+    "provider": "openrouter",
+    "apiKey": "OPENROUTER_API_KEY",
+    "model": "openrouter/moonshotai/kimi-k2.5"
+  }
+}
+```
+
+### Step 9: Build Host Code
+
+```bash
+npm run build
+```
+
+### Step 10: Test
+
+Tell the user:
+
+> OpenCode runtime configured! Send a message to the configured group to test.
+>
+> - Groups with `runtime: 'opencode'` will use OpenCode with the configured model
+> - Groups without `runtime` set (or `runtime: 'claude'`) continue using Claude Code
+> - Both runtimes share the same IPC protocol, so MCP tools, messaging, and scheduling all work identically
+
+---
+
+## Rollback
+
+To revert a group to Claude Code, remove `runtime` and `opencodeConfig` from its `containerConfig`. No code changes needed — the default runtime is `'claude'`.
+
+## Compatibility Notes
+
+| Claude Code feature | OpenCode equivalent | Notes |
+|--------------------|--------------------|----|
+| CLAUDE.md | Read natively | Falls back from AGENTS.md |
+| Container skills (.claude/skills/) | Agent Skills Standard | Same paths, same SKILL.md format |
+| MCP servers | Native MCP support | Same nanoclaw MCP server reused via opencode.json |
+| Hooks (sanitize bash) | Permission config | Container is already sandboxed; opencode permissions set to allow-all |
+| Session persistence | Built-in | OpenCode server mode maintains sessions automatically |

--- a/.claude/skills/add-opencode-runtime/opencode-sdk-reference.md
+++ b/.claude/skills/add-opencode-runtime/opencode-sdk-reference.md
@@ -1,228 +1,962 @@
-# @opencode-ai/sdk v1.2.6 — Interface Reference
+# @opencode-ai/sdk v1.2.9 — Comprehensive Reference
 
-This reference was derived from the package's TypeScript type definitions (npm tarball inspection). Covers the subset of the API used by the nanoclaw OpenCode runner.
+Derived from tarball inspection of `opencode-ai-sdk-1.2.9.tgz` (npm pack). All types are from
+`dist/src/gen/types.gen.d.ts` and `dist/src/gen/sdk.gen.d.ts` unless noted.
 
 ---
 
-## `createOpencode(options)` — Start server + get client
+## Package exports
+
+```
+@opencode-ai/sdk          → createOpencode(), createOpencodeClient(), all types
+@opencode-ai/sdk/client   → createOpencodeClient() only (no server)
+@opencode-ai/sdk/server   → createOpencodeServer(), createOpencodeTui()
+@opencode-ai/sdk/v2       → v2 API (same shape, some additions — see V2 section)
+```
+
+---
+
+## Top-level functions
+
+### `createOpencode(options?)` — start server + get client
 
 ```typescript
 import { createOpencode } from '@opencode-ai/sdk';
 
-const { client, server } = await createOpencode({
-  hostname: '127.0.0.1',   // bind address for the local OpenCode server
-  port: 4096,              // port to listen on
-  config?: {
-    model?: string;        // default model (e.g. 'anthropic/claude-sonnet-4-20250514')
-  },
-  // NOTE: 'cwd' is NOT a supported option — set process.env.OPENCODE_PROJECT instead
+const { client, server } = await createOpencode(options?: ServerOptions);
+// server.url: string — e.g. "http://127.0.0.1:4096"
+// server.close(): void — kills the server process
+```
+
+**ServerOptions:**
+```typescript
+type ServerOptions = {
+  hostname?: string;      // default "127.0.0.1"
+  port?: number;          // default 4096
+  signal?: AbortSignal;   // for cancellation
+  timeout?: number;       // ms to wait for server ready, default 5000
+  config?: Config;        // serialized as OPENCODE_CONFIG_CONTENT env var
+};
+```
+
+**Implementation note:** spawns `opencode serve --hostname=... --port=...` as a subprocess.
+Config is passed via `OPENCODE_CONFIG_CONTENT=JSON.stringify(config)` in the environment.
+Set `process.env.OPENCODE_PROJECT = '/path'` BEFORE calling to control project root.
+
+### `createOpencodeClient(config?)` — client only, no server
+
+```typescript
+import { createOpencodeClient } from '@opencode-ai/sdk/client';
+
+const client = createOpencodeClient({
+  baseURL: 'http://127.0.0.1:4096',
+  directory?: string,   // project directory filter for queries
 });
 ```
 
-**Returns:** `{ client: OpencodeClient, server: { close(): void } }`
+### `createOpencodeServer(options?)` — server only
 
-Set `process.env.OPENCODE_PROJECT = '/path/to/workspace'` before calling to control which directory OpenCode treats as the project root.
+```typescript
+import { createOpencodeServer } from '@opencode-ai/sdk/server';
 
-Call `server.close()` in a `finally` block to shut down the server process cleanly.
+const { url, close } = await createOpencodeServer(options?: ServerOptions);
+```
+
+### `createOpencodeTui(options?)` — launch TUI process
+
+```typescript
+import { createOpencodeTui } from '@opencode-ai/sdk/server';
+
+type TuiOptions = {
+  project?: string;
+  model?: string;
+  session?: string;   // open a specific session by ID
+  agent?: string;
+  signal?: AbortSignal;
+  config?: Config;
+};
+
+const tui = createOpencodeTui(options?: TuiOptions);
+tui.close(); // kill the TUI process
+```
 
 ---
 
-## `client.session`
+## `OpencodeClient` — top-level namespace
 
-### `session.create(options)` — Create a new session
+```typescript
+client.session        // Session management (primary API)
+client.event          // SSE event stream
+client.config         // Server config
+client.project        // Project info
+client.path           // Filesystem paths
+client.vcs            // VCS (git) info
+client.tool           // Tool introspection
+client.file           // File read/list/status
+client.find           // Search (text, files, symbols)
+client.app            // App logs, agent list
+client.mcp            // MCP server management
+client.lsp            // LSP server status
+client.formatter      // Formatter status
+client.provider       // Provider list/auth
+client.pty            // PTY (terminal) sessions
+client.instance       // Server instance management
+client.command        // Custom command list
+client.tui            // TUI control
+client.auth           // OAuth / API key auth
+client.global         // Global event stream (cross-directory)
+client.postSessionIdPermissionsPermissionId(options)  // Respond to permission requests
+```
+
+---
+
+## Session API (most important)
+
+### `client.session.list(options?)` — list sessions
+
+```typescript
+const result = await client.session.list({
+  query?: { directory?: string },
+});
+// result.data: Array<Session>
+// Filtered to sessions whose directory matches the query.directory value.
+// Returns ALL sessions for the project if no directory filter is given.
+```
+
+**This is key for session persistence:** use this to find existing sessions for a group
+after a container restart (filter by `directory: '/workspace/group'`).
+
+### `client.session.create(options?)` — create a new session
 
 ```typescript
 const result = await client.session.create({
   body?: {
-    title?: string;   // human-readable label for the session
+    parentID?: string;   // make this a child of another session
+    title?: string;      // human-readable label
   },
+  query?: { directory?: string },
 });
-
-// result shape:
-result.error  // truthy on failure — check before using result.data
-result.data   // { id: string, ... } on success
-
+// result.error — check before using result.data
+// result.data: Session
 const sessionId = result.data!.id;
 ```
 
-### `session.prompt(options)` — Send a message, wait for full response
+### `client.session.get(options)` — get session by ID
+
+```typescript
+const result = await client.session.get({
+  path: { id: string },
+  query?: { directory?: string },
+});
+// result.data: Session
+// Returns 404 NotFoundError if session does not exist.
+// Use this to verify a stored session ID is still valid.
+```
+
+### `client.session.prompt(options)` — send a message, wait for full response
 
 ```typescript
 const response = await client.session.prompt({
   path: { id: sessionId },
-  body: {
-    parts: Array<TextPartInput | FilePartInput | ...>;
-    messageID?: string;
+  body?: {
+    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>;
+    messageID?: string;              // client-supplied ID for idempotency
     model?: { providerID: string; modelID: string };
-    // ... other optional fields
+    agent?: string;                  // agent name to use
+    noReply?: boolean;               // send message without waiting for response
+    system?: string;                 // override system prompt
+    tools?: { [toolName: string]: boolean };
   },
+  query?: { directory?: string },
 });
-
-// response.data shape (on 200):
-// { info: AssistantMessage, parts: Array<Part> }
-
-// Extract text:
-const parts = response.data?.parts ?? [];
-const text = parts
-  .filter(p => p.type === 'text' && p.text)
-  .map(p => p.text!)
-  .join('');
+// response.data: { info: AssistantMessage; parts: Array<Part> }
 ```
 
-**This is a blocking long-poll.** It hits `POST /session/{id}/message` and only resolves when the LLM has finished generating. The full response is in `response.data.parts`.
+**BLOCKING long-poll.** Hits `POST /session/{id}/message` and resolves only when the LLM
+finishes generating. Full response is in `response.data.parts`.
 
-Do not confuse with `session.promptAsync()` — that hits `/session/{id}/prompt_async`, returns `void` immediately (fire-and-forget), and delivers the response only via SSE events.
+### `client.session.promptAsync(options)` — fire-and-forget prompt
 
-### `TextPartInput` — input part shape
+Hits `/session/{id}/prompt_async`, returns `void` immediately. Response comes via SSE events.
+Same body shape as `session.prompt()`.
+
+### `client.session.messages(options)` — list messages in a session
 
 ```typescript
-{ type: 'text', text: string }
+const result = await client.session.messages({
+  path: { id: sessionId },
+  query?: {
+    directory?: string;
+    limit?: number;
+  },
+});
+// result.data: Array<{ info: Message; parts: Array<Part> }>
+```
+
+### `client.session.update(options)` — update session properties
+
+```typescript
+await client.session.update({
+  path: { id: sessionId },
+  body?: { title?: string },
+  query?: { directory?: string },
+});
+// result.data: Session
+```
+
+### `client.session.delete(options)` — delete session and all data
+
+```typescript
+await client.session.delete({
+  path: { id: sessionId },
+  query?: { directory?: string },
+});
+// result.data: boolean
+```
+
+### `client.session.abort(options)` — abort in-progress session
+
+```typescript
+await client.session.abort({
+  path: { id: sessionId },
+  query?: { directory?: string },
+});
+// result.data: boolean
+```
+
+### `client.session.fork(options)` — fork session at a message
+
+```typescript
+const result = await client.session.fork({
+  path: { id: sessionId },
+  body?: { messageID?: string },  // fork point; defaults to latest
+  query?: { directory?: string },
+});
+// result.data: Session  (the new child session)
+```
+
+### `client.session.children(options)` — get child sessions
+
+```typescript
+const result = await client.session.children({
+  path: { id: sessionId },
+  query?: { directory?: string },
+});
+// result.data: Array<Session>
+```
+
+### `client.session.status(options?)` — get status of all sessions
+
+```typescript
+const result = await client.session.status();
+// result.data: { [sessionId: string]: SessionStatus }
+```
+
+### `client.session.summarize(options)` — trigger summarization
+
+```typescript
+await client.session.summarize({
+  path: { id: sessionId },
+  body?: { providerID: string; modelID: string },
+  query?: { directory?: string },
+});
+// result.data: boolean
+```
+
+### `client.session.todo(options)` — get todo list
+
+```typescript
+const result = await client.session.todo({
+  path: { id: sessionId },
+});
+// result.data: Array<Todo>
+```
+
+### `client.session.diff(options)` — get file diffs
+
+```typescript
+const result = await client.session.diff({
+  path: { id: sessionId },
+  query?: { directory?: string; messageID?: string },
+});
+// result.data: Array<FileDiff>
+```
+
+### `client.session.revert(options)` / `client.session.unrevert(options)` — undo/redo
+
+Revert to or restore from a message snapshot. See SessionRevertData/SessionUnrevertData types.
+
+### `client.session.shell(options)` — run a shell command in session context
+
+### `client.session.command(options)` — send a named command to a session
+
+### `client.session.init(options)` — analyze app and create AGENTS.md
+
+```typescript
+await client.session.init({
+  path: { id: sessionId },
+  body?: { modelID: string; providerID: string; messageID: string },
+});
+```
+
+### `client.postSessionIdPermissionsPermissionId(options)` — respond to permission request
+
+```typescript
+await client.postSessionIdPermissionsPermissionId({
+  path: { id: sessionId; permissionId: string },
+  body?: { response: 'once' | 'always' | 'reject' },
+});
 ```
 
 ---
 
-## `client.event`
+## Event stream
 
-### `event.subscribe()` — Subscribe to the SSE event stream
+### `client.event.subscribe()` — subscribe to SSE event stream
 
 ```typescript
 const { stream } = await client.event.subscribe();
 // stream: AsyncGenerator<Event, void, unknown>
+// Emits events for ALL sessions on this server instance.
 
 for await (const event of stream) {
-  // event is the discriminated Event union — switch on event.type
+  const evt = event as { type?: string; properties?: Record<string, unknown> };
+  // switch on evt.type
 }
 
 // Cleanup:
 await stream.return(undefined as never).catch(() => {});
 ```
 
-The stream is a persistent connection to the OpenCode server. It emits events for all activity across all sessions on the server instance.
+### `client.global.event()` — global event stream (cross-directory)
+
+Same shape as `client.event.subscribe()` but wraps each event as `{ directory, payload }`.
 
 ---
 
-## Event types
+## All event types (complete)
 
-All events have the shape `{ type: string; properties: <event-specific> }`.
+```typescript
+type Event =
+  | EventServerInstanceDisposed       // "server.instance.disposed"
+  | EventInstallationUpdated          // "installation.updated"
+  | EventInstallationUpdateAvailable  // "installation.update-available"
+  | EventLspClientDiagnostics         // "lsp.client.diagnostics"
+  | EventLspUpdated                   // "lsp.updated"
+  | EventMessageUpdated               // "message.updated"
+  | EventMessageRemoved               // "message.removed"
+  | EventMessagePartUpdated           // "message.part.updated"  ← streaming text
+  | EventMessagePartRemoved           // "message.part.removed"
+  | EventPermissionUpdated            // "permission.updated"    ← permission request
+  | EventPermissionReplied            // "permission.replied"
+  | EventSessionStatus                // "session.status"
+  | EventSessionIdle                  // "session.idle"          ← session finished
+  | EventSessionCompacted             // "session.compacted"     ← context compacted
+  | EventFileEdited                   // "file.edited"
+  | EventTodoUpdated                  // "todo.updated"
+  | EventCommandExecuted              // "command.executed"
+  | EventSessionCreated               // "session.created"
+  | EventSessionUpdated               // "session.updated"
+  | EventSessionDeleted               // "session.deleted"
+  | EventSessionDiff                  // "session.diff"
+  | EventSessionError                 // "session.error"
+  | EventFileWatcherUpdated           // "file.watcher.updated"
+  | EventVcsBranchUpdated             // "vcs.branch.updated"
+  | EventTuiPromptAppend              // "tui.prompt.append"
+  | EventTuiCommandExecute            // "tui.command.execute"
+  | EventTuiToastShow                 // "tui.toast.show"
+  | EventPtyCreated                   // "pty.created"
+  | EventPtyUpdated                   // "pty.updated"
+  | EventPtyExited                    // "pty.exited"
+  | EventPtyDeleted                   // "pty.deleted"
+  | EventServerConnected;             // "server.connected"
+```
 
-### Events relevant to nanoclaw
+### Event property shapes
 
-| Type | Properties | Notes |
-|------|-----------|-------|
-| `"message.part.updated"` | `{ part: Part, delta?: string }` | Fires as the assistant streams its reply |
-| `"message.updated"` | `{ info: Message }` | Fires when a full message is updated |
-| `"session.idle"` | `{ sessionID: string }` | Signals the session has finished processing |
-| `"session.error"` | `{ sessionID?: string, error?: unknown }` | Session-level error |
-| `"session.status"` | `{ sessionID: string, status: SessionStatus }` | Status transitions |
+```typescript
+// Streaming text (fires repeatedly during LLM generation)
+EventMessagePartUpdated: { part: Part; delta?: string }
+// part.text is FULL accumulated text (not a delta) — overwrite, don't append
 
-### Full event type list (for reference)
+// Session finished generating
+EventSessionIdle: { sessionID: string }
 
-`"server.instance.disposed"`, `"installation.updated"`, `"installation.update-available"`, `"lsp.client.diagnostics"`, `"lsp.updated"`, `"message.updated"`, `"message.removed"`, `"message.part.updated"`, `"message.part.removed"`, `"permission.updated"`, `"permission.replied"`, `"session.status"`, `"session.idle"`, `"session.compacted"`, `"session.diff"`, `"session.error"`, `"session.created"`, `"session.updated"`, `"session.deleted"`, `"file.edited"`, `"file.watcher.updated"`, `"vcs.branch.updated"`, `"todo.updated"`, `"command.executed"`, `"tui.prompt.append"`, `"tui.command.execute"`, `"tui.toast.show"`, `"pty.created"`, `"pty.updated"`, `"pty.exited"`, `"pty.deleted"`, `"server.connected"`
+// Context was compacted
+EventSessionCompacted: { sessionID: string }
+
+// Session status changed
+EventSessionStatus: { sessionID: string; status: SessionStatus }
+// SessionStatus = { type: "idle" } | { type: "busy" } | { type: "retry"; attempt: number; message: string; next: number }
+
+// Session lifecycle
+EventSessionCreated: { info: Session }
+EventSessionUpdated: { info: Session }
+EventSessionDeleted: { info: Session }
+
+// Permission request (tool needs approval)
+EventPermissionUpdated: Permission  // { id, type, pattern?, sessionID, messageID, callID?, title, metadata, time }
+EventPermissionReplied: { sessionID: string; permissionID: string; response: string }
+
+// Session error
+EventSessionError: { sessionID?: string; error?: ProviderAuthError | UnknownError | MessageOutputLengthError | MessageAbortedError | ApiError }
+
+// Message removed (e.g. after revert)
+EventMessageRemoved: { sessionID: string; messageID: string }
+
+// Message updated (full message object)
+EventMessageUpdated: { info: Message }
+
+// File changed
+EventFileEdited: { file: string }
+EventFileWatcherUpdated: { file: string; event: "add" | "change" | "unlink" }
+
+// Todo list updated
+EventTodoUpdated: { sessionID: string; todos: Array<Todo> }
+
+// Server instance disposed
+EventServerInstanceDisposed: { directory: string }
+
+// TUI events
+EventTuiPromptAppend: { text: string }
+EventTuiCommandExecute: { command: string }
+EventTuiToastShow: { title?: string; message: string; variant: "info"|"success"|"warning"|"error"; duration?: number }
+```
 
 ---
 
-## `message.part.updated` event — detailed shape
+## Core types
+
+### `Session`
 
 ```typescript
-{
-  type: 'message.part.updated',
-  properties: {
-    part: Part,      // full Part object — see below
-    delta?: string,  // optional: only the newly generated characters (incremental)
-  }
-}
+type Session = {
+  id: string;
+  projectID: string;
+  directory: string;      // project root directory this session belongs to
+  parentID?: string;      // set for child/forked sessions
+  title: string;
+  version: string;
+  time: {
+    created: number;      // ms timestamp
+    updated: number;
+    compacting?: number;  // set when compaction is in progress
+  };
+  summary?: {
+    additions: number;
+    deletions: number;
+    files: number;
+    diffs?: Array<FileDiff>;
+  };
+  share?: { url: string };
+  revert?: {
+    messageID: string;
+    partID?: string;
+    snapshot?: string;
+    diff?: string;
+  };
+};
 ```
 
-### `Part` — text variant
+### `Message` (discriminated union)
 
 ```typescript
-{
-  type: 'text',
-  text: string,    // FULL accumulated text so far (not a delta)
-  time: number,    // creation timestamp
-  delta?: string,  // optional incremental update
-}
+type Message = UserMessage | AssistantMessage;
+
+type UserMessage = {
+  id: string;
+  sessionID: string;
+  role: "user";
+  time: { created: number };
+  agent: string;
+  model: { providerID: string; modelID: string };
+  system?: string;
+  tools?: { [key: string]: boolean };
+  summary?: { title?: string; body?: string; diffs: Array<FileDiff> };
+};
+
+type AssistantMessage = {
+  id: string;
+  sessionID: string;
+  role: "assistant";
+  time: { created: number; completed?: number };
+  parentID: string;
+  modelID: string;
+  providerID: string;
+  mode: string;
+  path: { cwd: string; root: string };
+  cost: number;
+  tokens: {
+    input: number;
+    output: number;
+    reasoning: number;
+    cache: { read: number; write: number };
+  };
+  summary?: boolean;       // true if this is a summary/compaction message
+  finish?: string;
+  error?: ProviderAuthError | UnknownError | MessageOutputLengthError | MessageAbortedError | ApiError;
+};
 ```
 
-**Key behavior:** `part.text` always contains the **complete accumulated text** up to this event, not just the new characters. `delta` (if present) holds only the new characters. To capture the latest full text, overwrite rather than append:
+### `Part` (discriminated union — all variants)
 
 ```typescript
-if (evt.type === 'message.part.updated') {
-  const part = evt.properties.part;
-  if (part.type === 'text' && part.text) {
-    lastAssistantText = part.text;  // overwrite, not +=
-  }
-}
+type Part =
+  | TextPart          // type: "text"
+  | ReasoningPart     // type: "reasoning"
+  | FilePart          // type: "file"
+  | ToolPart          // type: "tool"
+  | StepStartPart     // type: "step-start"
+  | StepFinishPart    // type: "step-finish"
+  | SnapshotPart      // type: "snapshot"
+  | PatchPart         // type: "patch"
+  | AgentPart         // type: "agent"
+  | RetryPart         // type: "retry"
+  | CompactionPart    // type: "compaction"
+  | SubtaskPart;      // type: "subtask"  (inline in union)
+
+type TextPart = {
+  id: string; sessionID: string; messageID: string;
+  type: "text";
+  text: string;
+  synthetic?: boolean;
+  ignored?: boolean;
+  time?: { start: number; end?: number };
+  metadata?: { [key: string]: unknown };
+};
+
+type ReasoningPart = {
+  id: string; sessionID: string; messageID: string;
+  type: "reasoning";
+  text: string;
+  time: { start: number; end?: number };
+  metadata?: { [key: string]: unknown };
+};
+
+type ToolPart = {
+  id: string; sessionID: string; messageID: string;
+  type: "tool";
+  callID: string;
+  tool: string;
+  state: ToolStatePending | ToolStateRunning | ToolStateCompleted | ToolStateError;
+  metadata?: { [key: string]: unknown };
+};
+
+type ToolStatePending = { status: "pending"; input: Record<string, unknown>; raw: string };
+type ToolStateRunning = { status: "running"; input: Record<string, unknown>; title?: string; metadata?: Record<string, unknown>; time: { start: number } };
+type ToolStateCompleted = { status: "completed"; input: Record<string, unknown>; output: string; title: string; metadata: Record<string, unknown>; time: { start: number; end: number; compacted?: number }; attachments?: Array<FilePart> };
+type ToolStateError = { status: "error"; input: Record<string, unknown>; error: string; metadata?: Record<string, unknown>; time: { start: number; end: number } };
+
+type StepStartPart = { id: string; sessionID: string; messageID: string; type: "step-start"; snapshot?: string };
+type StepFinishPart = {
+  id: string; sessionID: string; messageID: string;
+  type: "step-finish";
+  reason: string;
+  snapshot?: string;
+  cost: number;
+  tokens: { input: number; output: number; reasoning: number; cache: { read: number; write: number } };
+};
+
+type CompactionPart = { id: string; sessionID: string; messageID: string; type: "compaction"; auto: boolean };
+// Appears in message.parts when context compaction occurred
+
+type SnapshotPart = { id: string; sessionID: string; messageID: string; type: "snapshot"; snapshot: string };
+type PatchPart = { id: string; sessionID: string; messageID: string; type: "patch"; hash: string; files: Array<string> };
+type AgentPart = { id: string; sessionID: string; messageID: string; type: "agent"; name: string; source?: { value: string; start: number; end: number } };
+type RetryPart = { id: string; sessionID: string; messageID: string; type: "retry"; attempt: number; error: ApiError; time: { created: number } };
+
+// SubtaskPart (inline union member):
+// { id: string; sessionID: string; messageID: string; type: "subtask"; prompt: string; description: string; agent: string }
+```
+
+### Input part types (for `session.prompt()`)
+
+```typescript
+type TextPartInput = { id?: string; type: "text"; text: string; synthetic?: boolean; ignored?: boolean; time?: { start: number; end?: number }; metadata?: Record<string, unknown> };
+type FilePartInput = { id?: string; type: "file"; mime: string; filename?: string; url: string; source?: FilePartSource };
+type AgentPartInput = { id?: string; type: "agent"; name: string; source?: { value: string; start: number; end: number } };
+type SubtaskPartInput = { id?: string; type: "subtask"; prompt: string; description: string; agent: string };
+```
+
+### `SessionStatus`
+
+```typescript
+type SessionStatus =
+  | { type: "idle" }
+  | { type: "busy" }
+  | { type: "retry"; attempt: number; message: string; next: number };
+```
+
+### Error types
+
+```typescript
+type ProviderAuthError = { name: "ProviderAuthError"; data: { providerID: string; message: string } };
+type UnknownError = { name: "UnknownError"; data: { message: string } };
+type MessageOutputLengthError = { name: "MessageOutputLengthError"; data: Record<string, unknown> };
+type MessageAbortedError = { name: "MessageAbortedError"; data: { message: string } };
+type ApiError = { name: "APIError"; data: { message: string; statusCode?: number; isRetryable: boolean; responseHeaders?: Record<string, string>; responseBody?: string } };
+
+type BadRequestError = { data: unknown; errors: Array<Record<string, unknown>>; success: false };
+type NotFoundError = { name: "NotFoundError"; data: { message: string } };
+```
+
+### `FileDiff`
+
+```typescript
+type FileDiff = { file: string; before: string; after: string; additions: number; deletions: number };
+```
+
+### `Todo`
+
+```typescript
+type Todo = { id: string; content: string; status: string; priority: string };
+```
+
+### `Path` — filesystem path info
+
+```typescript
+type Path = {
+  state: string;      // where OpenCode stores session data (e.g. ~/.local/share/opencode)
+  config: string;     // config directory
+  worktree: string;   // current worktree path
+  directory: string;  // current project directory
+};
+// Retrieve with: const paths = await client.path.get();
+```
+
+### `Project`
+
+```typescript
+type Project = {
+  id: string;
+  worktree: string;
+  vcsDir?: string;
+  vcs?: "git";
+  time: { created: number; initialized?: number };
+};
 ```
 
 ---
 
-## Typing events from the stream
-
-The SDK uses a discriminated union for `Event`. Because the nanoclaw runner casts via `unknown`, use this pattern:
+## `Config` type (opencode.json / OPENCODE_CONFIG_CONTENT)
 
 ```typescript
-for await (const event of stream) {
-  const evt = event as { type?: string; properties?: Record<string, unknown> };
+type Config = {
+  $schema?: string;
+  model?: string;                    // "provider/model-id"
+  small_model?: string;              // for lightweight tasks like title generation
+  theme?: string;
+  logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
+  username?: string;
 
-  if (evt.type === 'message.part.updated') {
-    const part = evt.properties?.part as { type: string; text?: string } | undefined;
-    if (part?.type === 'text' && part.text) {
-      // part.text is the full accumulated response text
-    }
-  }
+  // Instruction files to include (relative to project root or absolute paths)
+  instructions?: Array<string>;
 
-  if (evt.type === 'session.idle') {
-    const { sessionID } = evt.properties as { sessionID: string };
-    // session finished processing
-  }
-}
+  // Permission rules
+  permission?: {
+    edit?: "ask" | "allow" | "deny";
+    bash?: ("ask" | "allow" | "deny") | { [pattern: string]: "ask" | "allow" | "deny" };
+    webfetch?: "ask" | "allow" | "deny";
+    doom_loop?: "ask" | "allow" | "deny";
+    external_directory?: "ask" | "allow" | "deny";
+  };
+
+  // MCP servers
+  mcp?: {
+    [name: string]: McpLocalConfig | McpRemoteConfig;
+  };
+
+  // Provider configuration and overrides
+  provider?: { [providerID: string]: ProviderConfig };
+  enabled_providers?: Array<string>;   // whitelist — only these providers
+  disabled_providers?: Array<string>;  // blacklist
+
+  // Agent configuration
+  agent?: {
+    plan?: AgentConfig;
+    build?: AgentConfig;
+    general?: AgentConfig;
+    explore?: AgentConfig;
+    [name: string]: AgentConfig | undefined;  // custom agents
+  };
+
+  // Tool enable/disable overrides
+  tools?: { [toolName: string]: boolean };
+
+  // Custom slash commands
+  command?: {
+    [name: string]: { template: string; description?: string; agent?: string; model?: string; subtask?: boolean };
+  };
+
+  // LSP servers
+  lsp?: false | { [name: string]: { command: Array<string>; extensions?: Array<string>; disabled?: boolean; env?: Record<string, string>; initialization?: Record<string, unknown> } | { disabled: true } };
+
+  // Code formatters
+  formatter?: false | { [name: string]: { disabled?: boolean; command?: Array<string>; environment?: Record<string, string>; extensions?: Array<string> } };
+
+  // Sharing
+  share?: "manual" | "auto" | "disabled";
+  autoupdate?: boolean | "notify";
+  snapshot?: boolean;
+
+  // TUI settings
+  tui?: {
+    scroll_speed?: number;
+    scroll_acceleration?: { enabled: boolean };
+    diff_style?: "auto" | "stacked";
+  };
+
+  // Plugins (npm package IDs)
+  plugin?: Array<string>;
+
+  // File watcher ignore patterns
+  watcher?: { ignore?: Array<string> };
+
+  // Enterprise
+  enterprise?: { url?: string };
+
+  // Experimental features
+  experimental?: {
+    hook?: {
+      file_edited?: { [pattern: string]: Array<{ command: Array<string>; environment?: Record<string, string> }> };
+      session_completed?: Array<{ command: Array<string>; environment?: Record<string, string> }>;
+    };
+    chatMaxRetries?: number;
+    disable_paste_summary?: boolean;
+    batch_tool?: boolean;
+    openTelemetry?: boolean;
+    primary_tools?: Array<string>;
+  };
+
+  keybinds?: KeybindsConfig;
+  layout?: "auto" | "stretch";  // deprecated: always stretch
+};
+```
+
+### `McpLocalConfig`
+
+```typescript
+type McpLocalConfig = {
+  type: "local";
+  command: Array<string>;
+  environment?: { [key: string]: string };
+  enabled?: boolean;
+  timeout?: number;   // ms for tool fetch, default 5000
+};
+```
+
+### `McpRemoteConfig`
+
+```typescript
+type McpRemoteConfig = {
+  type: "remote";
+  url: string;
+  enabled?: boolean;
+  headers?: { [key: string]: string };
+  oauth?: McpOAuthConfig | false;   // false = disable OAuth auto-detection
+  timeout?: number;
+};
+```
+
+### `AgentConfig`
+
+```typescript
+type AgentConfig = {
+  model?: string;
+  temperature?: number;
+  top_p?: number;
+  prompt?: string;
+  tools?: { [toolName: string]: boolean };
+  disable?: boolean;
+  description?: string;
+  mode?: "subagent" | "primary" | "all";
+  color?: string;                    // hex color for TUI display
+  maxSteps?: number;                 // max agentic iterations before forcing text-only
+  permission?: { /* same as Config.permission */ };
+};
+```
+
+### `ProviderConfig`
+
+```typescript
+type ProviderConfig = {
+  api?: string;
+  name?: string;
+  env?: Array<string>;
+  id?: string;
+  npm?: string;
+  options?: {
+    apiKey?: string;
+    baseURL?: string;
+    enterpriseUrl?: string;     // GitHub Enterprise for Copilot
+    setCacheKey?: boolean;      // enable promptCacheKey
+    timeout?: number | false;   // request timeout, default 300000 (5 min)
+  };
+  models?: { [modelID: string]: { /* model overrides */ } };
+  whitelist?: Array<string>;
+  blacklist?: Array<string>;
+};
 ```
 
 ---
 
-## `opencode.json` config file
+## Session storage and persistence
 
-Written to the workspace root before starting the server. OpenCode reads it on startup.
+OpenCode stores session data in the `state` directory reported by `client.path.get()`.
+This is typically an XDG state path: `~/.local/share/opencode` on Linux, or a platform
+equivalent. It is NOT relative to `OPENCODE_PROJECT`.
 
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "model": "opencode/kimi-k2.5-free",
-  "permission": {
-    "edit": "allow",
-    "bash": "allow",
-    "webfetch": "allow"
-  },
-  "provider": {
-    "opencode": {}
-  },
-  "mcp": {
-    "my-server": {
-      "type": "local",
-      "command": ["node", "/path/to/server.js"],
-      "environment": {
-        "MY_VAR": "value"
+**For session persistence across container restarts:**
+- The state directory must be mounted from the host (add a volume mount for it)
+- Retrieve the path via `client.path.get()` to confirm the actual location in the container
+- After mounting, `session.list()` will return sessions from previous container invocations
+- Use `session.get({ path: { id } })` to verify a stored session ID still exists (returns 404 if not)
+- If valid, send the next prompt to the existing session ID via `session.prompt()`
+- If 404, create a new session with `session.create()`
+
+**Finding existing sessions for a group directory:**
+```typescript
+const result = await client.session.list({ query: { directory: '/workspace/group' } });
+const existing = result.data?.find(s => s.title === `nanoclaw-${groupFolder}`);
+```
+
+---
+
+## Other client APIs (brief)
+
+### `client.path.get()` — get filesystem paths
+
+```typescript
+const result = await client.path.get();
+// result.data: { state: string, config: string, worktree: string, directory: string }
+```
+
+### `client.config.get()` / `client.config.update()` — runtime config
+
+```typescript
+await client.config.get();            // → Config
+await client.config.update({ body: partialConfig });  // → Config
+await client.config.providers();      // → provider + model list
+```
+
+### `client.file.list()` / `.read()` / `.status()`
+
+```typescript
+await client.file.list({ path: { path: '/workspace/group' } });  // → Array<FileNode>
+await client.file.read({ path: { path: '/workspace/group/foo.ts' } });  // → FileContent
+await client.file.status();   // → git-status-like info
+```
+
+### `client.find.text()` / `.files()` / `.symbols()`
+
+Text search, file glob, and workspace symbol search.
+
+### `client.mcp.status()` / `.add()` / `.connect()` / `.disconnect()`
+
+Runtime MCP server management.
+
+### `client.instance.dispose()` — shut down server from client side
+
+```typescript
+await client.instance.dispose();
+// → boolean; triggers "server.instance.disposed" event
+```
+
+### `client.app.log()` — write to server logs
+
+```typescript
+await client.app.log({ body: { level: 'info', message: 'hello' } });
+```
+
+### `client.app.agents()` — list configured agents
+
+```typescript
+const result = await client.app.agents();
+// result.data: Array<Agent>
+```
+
+### `client.vcs.get()` — get current VCS branch
+
+```typescript
+const result = await client.vcs.get();
+// result.data: { branch: string }
+```
+
+### `client.project.list()` / `client.project.current()`
+
+```typescript
+const result = await client.project.current();
+// result.data: { id, worktree, vcsDir?, vcs?, time }
+```
+
+---
+
+## V2 API
+
+Import from `@opencode-ai/sdk/v2`. Same overall shape with additions:
+
+- **`Session`** gains: `slug: string`, `time.archived?: number`, `permission?: PermissionRuleset`
+- **`SessionCreate`** body gains: `permission?: PermissionRuleset`
+- **`SessionList`** query gains: `roots?: boolean`, `start?: number`, `search?: string`, `limit?: number`
+- **`SessionUpdate`** body gains: `time?: { archived?: number }`; path uses `sessionID` instead of `id`
+- **`AssistantMessage`** gains: `agent?: string`, `tokens.total?: number`, `structured?: unknown`, `variant?: string`, `format?: OutputFormat`
+- **`UserMessage`** gains: `variant?: string`, `format?: OutputFormat`
+- **`Part`** gains: `SubtaskPart` as distinct named type
+- **`Config`** gains: `compaction?: { auto?: boolean; prune?: boolean; reserved?: number }`; `experimental` gains `continue_loop_on_deny?: boolean`, `mcp_timeout?: number`
+- **Events** gain: `message.part.delta`, `permission.asked`, `worktree.ready`, `worktree.failed`, `mcp.tools.changed`, `mcp.browser.open.failed`
+
+---
+
+## Nanoclaw-specific usage patterns
+
+### Event loop with SSE fallback
+
+```typescript
+const { stream } = await client.event.subscribe();
+let lastAssistantText = '';
+
+const eventProcessor = (async () => {
+  try {
+    for await (const event of stream) {
+      const evt = event as { type?: string; properties?: Record<string, unknown> };
+      if (evt.type === 'message.part.updated') {
+        const part = (evt.properties?.part) as { type: string; text?: string } | undefined;
+        if (part?.type === 'text' && part.text) {
+          lastAssistantText = part.text;  // overwrite (not append) — always full accumulated text
+        }
       }
     }
-  },
-  "instructions": ["CLAUDE.md"]
+  } catch { /* stream ended */ }
+})();
+```
+
+### Casting events from SSE stream
+
+The SDK uses a discriminated union internally, but arrives as `unknown` at runtime.
+Cast with:
+```typescript
+const evt = event as { type?: string; properties?: Record<string, unknown> };
+if (evt.type === 'session.idle') {
+  const { sessionID } = evt.properties as { sessionID: string };
 }
 ```
 
-**Provider examples:**
+### Session persistence pattern
 
-| Provider | `provider` key | `model` format | API key needed? |
-|----------|---------------|----------------|-----------------|
-| OpenCode Zen | `"opencode"` | `"opencode/kimi-k2.5-free"` | No |
-| OpenRouter | `"openrouter"` | `"openrouter/moonshotai/kimi-k2.5"` | Yes |
-| Anthropic | `"anthropic"` | `"anthropic/claude-sonnet-4-20250514"` | Yes (or uses env) |
-
-To pass an API key, add it under the provider object:
-```json
-"provider": {
-  "openrouter": { "apiKey": "sk-or-..." }
+```typescript
+// On container start, if containerInput.sessionId is set:
+let sessionId: string;
+if (containerInput.sessionId) {
+  const check = await client.session.get({ path: { id: containerInput.sessionId } });
+  if (check.error) {
+    // Session not found — create new
+    const created = await client.session.create({ body: { title: `nanoclaw-${groupFolder}` } });
+    sessionId = created.data!.id;
+  } else {
+    sessionId = containerInput.sessionId;  // reuse existing
+  }
+} else {
+  const created = await client.session.create({ body: { title: `nanoclaw-${groupFolder}` } });
+  sessionId = created.data!.id;
 }
 ```
-
-For providers that read from environment variables (e.g. `ANTHROPIC_API_KEY`), the key field can be omitted entirely.

--- a/.claude/skills/add-opencode-runtime/opencode-sdk-reference.md
+++ b/.claude/skills/add-opencode-runtime/opencode-sdk-reference.md
@@ -1,0 +1,228 @@
+# @opencode-ai/sdk v1.2.6 — Interface Reference
+
+This reference was derived from the package's TypeScript type definitions (npm tarball inspection). Covers the subset of the API used by the nanoclaw OpenCode runner.
+
+---
+
+## `createOpencode(options)` — Start server + get client
+
+```typescript
+import { createOpencode } from '@opencode-ai/sdk';
+
+const { client, server } = await createOpencode({
+  hostname: '127.0.0.1',   // bind address for the local OpenCode server
+  port: 4096,              // port to listen on
+  config?: {
+    model?: string;        // default model (e.g. 'anthropic/claude-sonnet-4-20250514')
+  },
+  // NOTE: 'cwd' is NOT a supported option — set process.env.OPENCODE_PROJECT instead
+});
+```
+
+**Returns:** `{ client: OpencodeClient, server: { close(): void } }`
+
+Set `process.env.OPENCODE_PROJECT = '/path/to/workspace'` before calling to control which directory OpenCode treats as the project root.
+
+Call `server.close()` in a `finally` block to shut down the server process cleanly.
+
+---
+
+## `client.session`
+
+### `session.create(options)` — Create a new session
+
+```typescript
+const result = await client.session.create({
+  body?: {
+    title?: string;   // human-readable label for the session
+  },
+});
+
+// result shape:
+result.error  // truthy on failure — check before using result.data
+result.data   // { id: string, ... } on success
+
+const sessionId = result.data!.id;
+```
+
+### `session.prompt(options)` — Send a message, wait for full response
+
+```typescript
+const response = await client.session.prompt({
+  path: { id: sessionId },
+  body: {
+    parts: Array<TextPartInput | FilePartInput | ...>;
+    messageID?: string;
+    model?: { providerID: string; modelID: string };
+    // ... other optional fields
+  },
+});
+
+// response.data shape (on 200):
+// { info: AssistantMessage, parts: Array<Part> }
+
+// Extract text:
+const parts = response.data?.parts ?? [];
+const text = parts
+  .filter(p => p.type === 'text' && p.text)
+  .map(p => p.text!)
+  .join('');
+```
+
+**This is a blocking long-poll.** It hits `POST /session/{id}/message` and only resolves when the LLM has finished generating. The full response is in `response.data.parts`.
+
+Do not confuse with `session.promptAsync()` — that hits `/session/{id}/prompt_async`, returns `void` immediately (fire-and-forget), and delivers the response only via SSE events.
+
+### `TextPartInput` — input part shape
+
+```typescript
+{ type: 'text', text: string }
+```
+
+---
+
+## `client.event`
+
+### `event.subscribe()` — Subscribe to the SSE event stream
+
+```typescript
+const { stream } = await client.event.subscribe();
+// stream: AsyncGenerator<Event, void, unknown>
+
+for await (const event of stream) {
+  // event is the discriminated Event union — switch on event.type
+}
+
+// Cleanup:
+await stream.return(undefined as never).catch(() => {});
+```
+
+The stream is a persistent connection to the OpenCode server. It emits events for all activity across all sessions on the server instance.
+
+---
+
+## Event types
+
+All events have the shape `{ type: string; properties: <event-specific> }`.
+
+### Events relevant to nanoclaw
+
+| Type | Properties | Notes |
+|------|-----------|-------|
+| `"message.part.updated"` | `{ part: Part, delta?: string }` | Fires as the assistant streams its reply |
+| `"message.updated"` | `{ info: Message }` | Fires when a full message is updated |
+| `"session.idle"` | `{ sessionID: string }` | Signals the session has finished processing |
+| `"session.error"` | `{ sessionID?: string, error?: unknown }` | Session-level error |
+| `"session.status"` | `{ sessionID: string, status: SessionStatus }` | Status transitions |
+
+### Full event type list (for reference)
+
+`"server.instance.disposed"`, `"installation.updated"`, `"installation.update-available"`, `"lsp.client.diagnostics"`, `"lsp.updated"`, `"message.updated"`, `"message.removed"`, `"message.part.updated"`, `"message.part.removed"`, `"permission.updated"`, `"permission.replied"`, `"session.status"`, `"session.idle"`, `"session.compacted"`, `"session.diff"`, `"session.error"`, `"session.created"`, `"session.updated"`, `"session.deleted"`, `"file.edited"`, `"file.watcher.updated"`, `"vcs.branch.updated"`, `"todo.updated"`, `"command.executed"`, `"tui.prompt.append"`, `"tui.command.execute"`, `"tui.toast.show"`, `"pty.created"`, `"pty.updated"`, `"pty.exited"`, `"pty.deleted"`, `"server.connected"`
+
+---
+
+## `message.part.updated` event — detailed shape
+
+```typescript
+{
+  type: 'message.part.updated',
+  properties: {
+    part: Part,      // full Part object — see below
+    delta?: string,  // optional: only the newly generated characters (incremental)
+  }
+}
+```
+
+### `Part` — text variant
+
+```typescript
+{
+  type: 'text',
+  text: string,    // FULL accumulated text so far (not a delta)
+  time: number,    // creation timestamp
+  delta?: string,  // optional incremental update
+}
+```
+
+**Key behavior:** `part.text` always contains the **complete accumulated text** up to this event, not just the new characters. `delta` (if present) holds only the new characters. To capture the latest full text, overwrite rather than append:
+
+```typescript
+if (evt.type === 'message.part.updated') {
+  const part = evt.properties.part;
+  if (part.type === 'text' && part.text) {
+    lastAssistantText = part.text;  // overwrite, not +=
+  }
+}
+```
+
+---
+
+## Typing events from the stream
+
+The SDK uses a discriminated union for `Event`. Because the nanoclaw runner casts via `unknown`, use this pattern:
+
+```typescript
+for await (const event of stream) {
+  const evt = event as { type?: string; properties?: Record<string, unknown> };
+
+  if (evt.type === 'message.part.updated') {
+    const part = evt.properties?.part as { type: string; text?: string } | undefined;
+    if (part?.type === 'text' && part.text) {
+      // part.text is the full accumulated response text
+    }
+  }
+
+  if (evt.type === 'session.idle') {
+    const { sessionID } = evt.properties as { sessionID: string };
+    // session finished processing
+  }
+}
+```
+
+---
+
+## `opencode.json` config file
+
+Written to the workspace root before starting the server. OpenCode reads it on startup.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "opencode/kimi-k2.5-free",
+  "permission": {
+    "edit": "allow",
+    "bash": "allow",
+    "webfetch": "allow"
+  },
+  "provider": {
+    "opencode": {}
+  },
+  "mcp": {
+    "my-server": {
+      "type": "local",
+      "command": ["node", "/path/to/server.js"],
+      "environment": {
+        "MY_VAR": "value"
+      }
+    }
+  },
+  "instructions": ["CLAUDE.md"]
+}
+```
+
+**Provider examples:**
+
+| Provider | `provider` key | `model` format | API key needed? |
+|----------|---------------|----------------|-----------------|
+| OpenCode Zen | `"opencode"` | `"opencode/kimi-k2.5-free"` | No |
+| OpenRouter | `"openrouter"` | `"openrouter/moonshotai/kimi-k2.5"` | Yes |
+| Anthropic | `"anthropic"` | `"anthropic/claude-sonnet-4-20250514"` | Yes (or uses env) |
+
+To pass an API key, add it under the provider object:
+```json
+"provider": {
+  "openrouter": { "apiKey": "sk-or-..." }
+}
+```
+
+For providers that read from environment variables (e.g. `ANTHROPIC_API_KEY`), the key field can be omitted entirely.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && apt-get install -y \
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
-# Install agent-browser and claude-code globally
-RUN npm install -g agent-browser @anthropic-ai/claude-code
+# Install agent-browser, claude-code, and opencode globally
+RUN npm install -g agent-browser @anthropic-ai/claude-code opencode-ai
 
 # Create app directory
 WORKDIR /app

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 # Create entrypoint script
 # Secrets are passed via stdin JSON — temp file is deleted immediately after Node reads it
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
-RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\ncd /workspace/group && node /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -12,7 +12,8 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.34",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "cron-parser": "^5.0.0",
-    "zod": "^4.0.0"
+    "zod": "^4.0.0",
+    "@opencode-ai/sdk": "^1.2.6"
   },
   "devDependencies": {
     "@types/node": "^22.10.7",

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -27,11 +27,6 @@ interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   secrets?: Record<string, string>;
-  modelProvider?: {
-    baseUrl?: string;
-    apiKey?: string;
-    model?: string;
-  };
   runtime?: 'claude' | 'opencode';
   opencodeConfig?: {
     provider?: string;
@@ -531,21 +526,6 @@ async function main(): Promise<void> {
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
   for (const [key, value] of Object.entries(containerInput.secrets || {})) {
     sdkEnv[key] = value;
-  }
-
-  // Inject model provider overrides (OpenRouter, custom endpoints, etc.)
-  if (containerInput.modelProvider) {
-    const mp = containerInput.modelProvider;
-    if (mp.baseUrl) {
-      sdkEnv.ANTHROPIC_BASE_URL = mp.baseUrl;
-    }
-    if (mp.apiKey && containerInput.secrets?.[mp.apiKey]) {
-      sdkEnv.ANTHROPIC_API_KEY = containerInput.secrets[mp.apiKey];
-    }
-    if (mp.model) {
-      sdkEnv.ANTHROPIC_MODEL = mp.model;
-    }
-    log(`Model provider configured: base=${mp.baseUrl || 'default'} model=${mp.model || 'default'}`);
   }
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/container/agent-runner/src/opencode-runner.ts
+++ b/container/agent-runner/src/opencode-runner.ts
@@ -1,0 +1,296 @@
+/**
+ * OpenCode Agent Runner
+ * Alternative runtime that uses OpenCode instead of Claude Code SDK.
+ * Same stdin/stdout protocol and IPC mechanism as the Claude runner.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createOpencode } from '@opencode-ai/sdk';
+
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  secrets?: Record<string, string>;
+  modelProvider?: { baseUrl?: string; apiKey?: string; model?: string };
+  runtime?: string;
+  opencodeConfig?: {
+    provider?: string;
+    apiKey?: string;
+    model?: string;
+  };
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+const IPC_INPUT_DIR = '/workspace/ipc/input';
+const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+const IPC_POLL_MS = 500;
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+function log(message: string): void {
+  console.error(`[opencode-runner] ${message}`);
+}
+
+function shouldClose(): boolean {
+  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    return true;
+  }
+  return false;
+}
+
+function drainIpcInput(): string[] {
+  try {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+    const files = fs.readdirSync(IPC_INPUT_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    const messages: string[] = [];
+    for (const file of files) {
+      const filePath = path.join(IPC_INPUT_DIR, file);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        fs.unlinkSync(filePath);
+        if (data.type === 'message' && data.text) {
+          messages.push(data.text);
+        }
+      } catch (err) {
+        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
+        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      }
+    }
+    return messages;
+  } catch (err) {
+    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+function waitForIpcMessage(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (shouldClose()) {
+        resolve(null);
+        return;
+      }
+      const messages = drainIpcInput();
+      if (messages.length > 0) {
+        resolve(messages.join('\n'));
+        return;
+      }
+      setTimeout(poll, IPC_POLL_MS);
+    };
+    poll();
+  });
+}
+
+/**
+ * Write opencode.json config to the workspace.
+ */
+function writeOpencodeConfig(containerInput: ContainerInput): void {
+  const oc = containerInput.opencodeConfig;
+  const provider = oc?.provider || 'anthropic';
+  const model = oc?.model || 'anthropic/claude-sonnet-4-20250514';
+
+  // Resolve API key from secrets (only if explicitly configured)
+  const apiKey = oc?.apiKey && containerInput.secrets?.[oc.apiKey]
+    ? containerInput.secrets[oc.apiKey]
+    : undefined;
+
+  // MCP server path (compiled dist location at container runtime)
+  const mcpServerPath = '/tmp/dist/ipc-mcp-stdio.js';
+
+  const config: Record<string, unknown> = {
+    $schema: 'https://opencode.ai/config.json',
+    model,
+    permission: {
+      edit: 'allow',
+      bash: 'allow',
+      webfetch: 'allow',
+    },
+    provider: {
+      [provider]: {
+        ...(apiKey ? { apiKey } : {}),
+      },
+    },
+    mcp: {
+      nanoclaw: {
+        type: 'local',
+        command: ['node', mcpServerPath],
+        environment: {
+          NANOCLAW_CHAT_JID: containerInput.chatJid,
+          NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+          NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+        },
+      },
+    },
+    // Load CLAUDE.md and any additional instruction files
+    instructions: ['CLAUDE.md'],
+  };
+
+  const configPath = '/workspace/group/opencode.json';
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  log(`Wrote opencode.json to ${configPath}`);
+}
+
+/**
+ * Extract text from message parts.
+ */
+function extractText(parts: Array<{ type: string; text?: string }>): string {
+  return parts
+    .filter(p => p.type === 'text' && p.text)
+    .map(p => p.text!)
+    .join('');
+}
+
+export async function runOpenCode(containerInput: ContainerInput): Promise<void> {
+  log('Starting OpenCode runtime...');
+
+  // Write opencode.json configuration
+  writeOpencodeConfig(containerInput);
+
+  // Set project directory for OpenCode server
+  process.env.OPENCODE_PROJECT = '/workspace/group';
+
+  // Start OpenCode server and get client
+  const { client, server } = await createOpencode({
+    hostname: '127.0.0.1',
+    port: 4096,
+    config: {
+      model: containerInput.opencodeConfig?.model || 'anthropic/claude-sonnet-4-20250514',
+    },
+  });
+
+  log('OpenCode server started');
+
+  try {
+    // Create a session
+    const sessionResult = await client.session.create({
+      body: { title: `nanoclaw-${containerInput.groupFolder}` },
+    });
+    if (sessionResult.error) {
+      throw new Error(`Failed to create session: ${JSON.stringify(sessionResult.error)}`);
+    }
+    const sessionId = sessionResult.data!.id;
+    log(`Session created: ${sessionId}`);
+
+    // Set up SSE event stream for real-time updates
+    const eventResult = await client.event.subscribe();
+    const eventStream = eventResult.stream;
+    let lastAssistantText = '';
+
+    // Process events in background
+    const eventProcessor = (async () => {
+      try {
+        for await (const event of eventStream) {
+          const evt = event as { type?: string; properties?: Record<string, unknown> };
+          if (evt.type === 'message.part.updated') {
+            const part = (evt.properties?.part) as { type: string; text?: string } | undefined;
+            if (part?.type === 'text' && part.text) {
+              lastAssistantText = part.text;
+            }
+          }
+        }
+      } catch {
+        // Stream ended or aborted
+      }
+    })();
+
+    // Build initial prompt
+    let prompt = containerInput.prompt;
+    if (containerInput.isScheduledTask) {
+      prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
+    }
+    const pending = drainIpcInput();
+    if (pending.length > 0) {
+      log(`Draining ${pending.length} pending IPC messages into initial prompt`);
+      prompt += '\n' + pending.join('\n');
+    }
+
+    // Query loop: send prompt → wait for IPC → repeat
+    while (true) {
+      log(`Sending prompt (${prompt.length} chars)...`);
+      lastAssistantText = '';
+
+      try {
+        const response = await client.session.prompt({
+          path: { id: sessionId },
+          body: {
+            parts: [{ type: 'text' as const, text: prompt }],
+          },
+        });
+
+        // Extract result from response
+        let result: string | null = null;
+        if (response.data?.parts) {
+          result = extractText(response.data.parts as Array<{ type: string; text?: string }>) || null;
+        }
+        if (!result && lastAssistantText) {
+          result = lastAssistantText;
+        }
+
+        log(`Got response: ${result ? result.slice(0, 200) : '(empty)'}...`);
+
+        writeOutput({
+          status: 'success',
+          result,
+          newSessionId: sessionId,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log(`Query error: ${errorMessage}`);
+        writeOutput({
+          status: 'error',
+          result: null,
+          newSessionId: sessionId,
+          error: errorMessage,
+        });
+      }
+
+      // Check for close before waiting
+      if (shouldClose()) {
+        log('Close sentinel received after query, exiting');
+        break;
+      }
+
+      // Emit session update so host can track it
+      writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+
+      // Wait for next IPC message or close
+      log('Waiting for next IPC message...');
+      const nextMessage = await waitForIpcMessage();
+      if (nextMessage === null) {
+        log('Close sentinel received, exiting');
+        break;
+      }
+
+      log(`Got new message (${nextMessage.length} chars), starting new query`);
+      prompt = nextMessage;
+    }
+
+    // Clean up — signal the async generator to stop
+    await eventStream.return(undefined as never).catch(() => {});
+    await eventProcessor.catch(() => {});
+  } finally {
+    server.close();
+    log('OpenCode server stopped');
+  }
+}

--- a/container/agent-runner/src/opencode-runner.ts
+++ b/container/agent-runner/src/opencode-runner.ts
@@ -153,8 +153,14 @@ function writeOpencodeConfig(containerInput: ContainerInput): void {
         },
       },
     },
-    // Load CLAUDE.md and any additional instruction files
-    instructions: ['CLAUDE.md'],
+    // Load CLAUDE.md and any additional instruction files.
+    // Non-main groups also get the global CLAUDE.md (matches Claude runtime behaviour).
+    instructions: [
+      'CLAUDE.md',
+      ...(!containerInput.isMain && fs.existsSync('/workspace/global/CLAUDE.md')
+        ? ['/workspace/global/CLAUDE.md']
+        : []),
+    ],
   };
 
   const configPath = '/workspace/group/opencode.json';

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -1,6 +1,6 @@
-# Andy
+# Kit
 
-You are Andy, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
+You are Kit, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
 
 ## What You Can Do
 
@@ -56,3 +56,20 @@ NEVER use markdown. Only use WhatsApp/Telegram formatting:
 - ```triple backticks``` for code
 
 No ## headings. No [links](url). No **double stars**.
+
+## User Preferences
+
+### Timezone
+Ankur is in the US Eastern timezone (ET). All times communicated to him should be in ET format (e.g. "7:12 PM ET"), and when scheduling tasks based on his requests, interpret his times as ET.
+
+The server (and container) runs on UTC. When scheduling tasks, convert ET to UTC:
+- EST (winter) = UTC-5
+- EDT (summer) = UTC-4
+
+DST in the US starts the second Sunday of March and ends the first Sunday of November.
+
+**IMPORTANT:** Always use the `date` command to get the current time in both UTC and ET before doing timezone conversions:
+```bash
+date -u +"UTC: %Y-%m-%d %H:%M:%S" && TZ='America/New_York' date +"ET:  %Y-%m-%d %H:%M:%S %Z"
+```
+This prevents manual calculation errors. When scheduling tasks, calculate the target UTC time by adding/subtracting from the current UTC time shown by the command.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -164,6 +164,18 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // OpenCode runtime: mount per-group state directory so sessions persist across container restarts.
+  // XDG_STATE_HOME is set to /workspace/opencode-state in opencode-runner.ts.
+  if (group.containerConfig?.runtime === 'opencode') {
+    const opencodeStateDir = path.join(DATA_DIR, 'opencode-state', group.folder);
+    fs.mkdirSync(opencodeStateDir, { recursive: true });
+    mounts.push({
+      hostPath: opencodeStateDir,
+      containerPath: '/workspace/opencode-state',
+      readonly: false,
+    });
+  }
+
   // Mount agent-runner source from host — recompiled on container startup.
   const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
   mounts.push({

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,16 +27,9 @@ export interface AllowedRoot {
   description?: string;
 }
 
-export interface ModelProvider {
-  baseUrl?: string;    // e.g. "https://openrouter.ai/api/v1"
-  apiKey?: string;     // Env var NAME to read from .env (e.g. "OPENROUTER_API_KEY")
-  model?: string;      // e.g. "moonshotai/kimi-k2.5"
-}
-
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
-  modelProvider?: ModelProvider;
   runtime?: 'claude' | 'opencode';   // Default: 'claude'
   opencodeConfig?: {
     provider?: string;     // e.g. 'openrouter', 'anthropic'

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,9 +27,22 @@ export interface AllowedRoot {
   description?: string;
 }
 
+export interface ModelProvider {
+  baseUrl?: string;    // e.g. "https://openrouter.ai/api/v1"
+  apiKey?: string;     // Env var NAME to read from .env (e.g. "OPENROUTER_API_KEY")
+  model?: string;      // e.g. "moonshotai/kimi-k2.5"
+}
+
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
+  modelProvider?: ModelProvider;
+  runtime?: 'claude' | 'opencode';   // Default: 'claude'
+  opencodeConfig?: {
+    provider?: string;     // e.g. 'openrouter', 'anthropic'
+    apiKey?: string;       // Env var NAME (e.g. "OPENROUTER_API_KEY")
+    model?: string;        // e.g. 'openrouter/moonshotai/kimi-k2.5'
+  };
 }
 
 export interface RegisteredGroup {


### PR DESCRIPTION

OpenCode as alternative runtime with server mode, SSE streaming, native MCP support, and session persistence. Per-group runtime selection with 'claude' (default) or 'opencode'.

**Status**: working on my instance, could use more feedback to verify the skill is working well. 

This PR contains the new skill and the changes it produces to my instance. If it works well enough, I'd be happy to contribute the skill upstream.

There's a bonus skill to add-model-provider, for other providers of Anthropic models. I'm not using this in my instance. But it might be useful for someone else.


## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
